### PR TITLE
Add `update` to `from_experiment`

### DIFF
--- a/docs/examples/notebooks/transfer_function_example.ipynb
+++ b/docs/examples/notebooks/transfer_function_example.ipynb
@@ -28,6 +28,14 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d43ea04c-cec6-419c-9926-bb0d2c1b34b2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "id": "a6ad495f-36cc-437b-9214-e4a503985720",
    "metadata": {},

--- a/mth5/mth5.py
+++ b/mth5/mth5.py
@@ -846,7 +846,7 @@ class MTH5:
                 experiment = self.experiment_group.metadata
             return experiment
 
-    def from_experiment(self, experiment, survey_index=0):
+    def from_experiment(self, experiment, survey_index=0, update=False):
         """
         Fill out an MTH5 from a :class:`mt_metadata.timeseries.Experiment` object
         given a survey_id
@@ -864,15 +864,24 @@ class MTH5:
                 sg.write_metadata()
                 for station in experiment.surveys[0].stations:
                     mt_station = self.add_station(station.id, station_metadata=station)
+                    if update:
+                        mt_station.metadata.update(station)
+                        mt_station.write_metadata()
                     for run in station.runs:
                         mt_run = mt_station.add_run(run.id, run_metadata=run)
+                        if update:
+                            mt_run.metadata.update(run)
+                            mt_run.write_metadata()
                         for channel in run.channels:
-                            mt_run.add_channel(
+                            mt_ch = mt_run.add_channel(
                                 channel.component,
                                 channel.type,
                                 None,
                                 channel_metadata=channel,
                             )
+                            if update:
+                                mt_ch.metadata.update(channel)
+                                mt_ch.write_metadata()
 
                 for k, v in experiment.surveys[0].filters.items():
                     self.filters_group.add_filter(v)
@@ -886,15 +895,24 @@ class MTH5:
                         mt_station = self.add_station(
                             station.id, station_metadata=station, survey=sg.metadata.id
                         )
+                        if update:
+                            mt_station.metadata.update(station)
+                            mt_station.write_metadata()
                         for run in station.runs:
                             mt_run = mt_station.add_run(run.id, run_metadata=run)
+                            if update:
+                                mt_run.metadata.update(run)
+                                mt_run.write_metadata()
                             for channel in run.channels:
-                                mt_run.add_channel(
+                                mt_ch = mt_run.add_channel(
                                     channel.component,
                                     channel.type,
                                     None,
                                     channel_metadata=channel,
                                 )
+                                if update:
+                                    mt_ch.metadata.update(channel)
+                                    mt_ch.write_metadata()
 
                     for k, v in survey.filters.items():
                         sg.filters_group.add_filter(v)

--- a/tests/version_1/test_build_from_experiment.py
+++ b/tests/version_1/test_build_from_experiment.py
@@ -133,3 +133,31 @@ class TestMTH5(unittest.TestCase):
     def tearDown(self):
         self.mth5_obj.close_mth5()
         self.fn.unlink()
+        
+class TestUpdateFromExperiment(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+        self.fn = fn_path.joinpath("test.h5")
+        self.mth5_obj = mth5.MTH5(file_version="0.1.0")
+        self.mth5_obj.open_mth5(self.fn, mode="w")
+        self.experiment = Experiment()
+        self.experiment.from_xml(fn=MT_EXPERIMENT_SINGLE_STATION)
+        self.mth5_obj.from_experiment(self.experiment)
+        
+        self.experiment_02 = Experiment()
+        self.experiment_02.from_xml(fn=MT_EXPERIMENT_SINGLE_STATION)
+        self.experiment_02.surveys[0].id = "different_survey_name"
+        self.experiment_02.surveys[0].stations[0].id = "different_station_name"
+        
+    def test_update_from_new_experiment(self):
+        
+        self.mth5_obj.from_experiment(self.experiment_02, update=True)
+        
+        with self.subTest("new_survey"):
+            self.assertEqual(self.mth5_obj.survey_group.metadata.id,
+                             self.experiment_02.surveys[0].id)
+            
+        # with self.subTest("new_station"):
+        #     self.assertEqual(self.mth5_obj.survey_group.metadata.id,
+        #                      self.experiment_02.surveys[0].id)
+            

--- a/tests/version_1/test_build_from_experiment.py
+++ b/tests/version_1/test_build_from_experiment.py
@@ -147,7 +147,8 @@ class TestUpdateFromExperiment(unittest.TestCase):
         self.experiment_02 = Experiment()
         self.experiment_02.from_xml(fn=MT_EXPERIMENT_SINGLE_STATION)
         self.experiment_02.surveys[0].id = "different_survey_name"
-        self.experiment_02.surveys[0].stations[0].id = "different_station_name"
+        self.experiment_02.surveys[0].stations[0].location.latitude = 10
+        
         
     def test_update_from_new_experiment(self):
         
@@ -157,7 +158,13 @@ class TestUpdateFromExperiment(unittest.TestCase):
             self.assertEqual(self.mth5_obj.survey_group.metadata.id,
                              self.experiment_02.surveys[0].id)
             
-        # with self.subTest("new_station"):
-        #     self.assertEqual(self.mth5_obj.survey_group.metadata.id,
-        #                      self.experiment_02.surveys[0].id)
+        with self.subTest("new_location"):
+            st = self.mth5_obj.get_station("REW09")
+            self.assertEqual(
+                st.metadata.location.latitude,
+                self.experiment_02.surveys[0].stations[0].location.latitude)
+            
+    def tearDown(self):
+        self.mth5_obj.close_mth5()
+        self.fn.unlink()
             

--- a/tests/version_1/test_from_stationxml.py
+++ b/tests/version_1/test_from_stationxml.py
@@ -158,6 +158,16 @@ class TestFromStationXML01(unittest.TestCase):
         for key, true_value in ch_dict.items():
             with self.subTest(msg=key):
                 self.assertEqual(true_value, m_ch.get_attr_from_name(key))
+                
+    def test_filters(self):
+        
+        for f_name in self.experiment.surveys[0].filters.keys():
+            with self.subTest(f_name):
+                exp_filter = self.experiment.surveys[0].filters[f_name]
+                h5_filter = self.m.survey_group.filters_group.to_filter_object(f_name)
+                
+                self.assertTrue(exp_filter, h5_filter)        
+        
 
     def tearDown(self):
         self.m.close_mth5()

--- a/tests/version_2/test_build_from_experiment.py
+++ b/tests/version_2/test_build_from_experiment.py
@@ -151,3 +151,37 @@ class TestMTH5(unittest.TestCase):
     def tearDown(self):
         self.mth5_obj.close_mth5()
         self.fn.unlink()
+        
+class TestUpdateFromExperiment(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+        self.fn = fn_path.joinpath("test.h5")
+        self.mth5_obj = mth5.MTH5(file_version="0.1.0")
+        self.mth5_obj.open_mth5(self.fn, mode="w")
+        self.experiment = Experiment()
+        self.experiment.from_xml(fn=MT_EXPERIMENT_SINGLE_STATION)
+        self.mth5_obj.from_experiment(self.experiment)
+        
+        self.experiment_02 = Experiment()
+        self.experiment_02.from_xml(fn=MT_EXPERIMENT_SINGLE_STATION)
+        self.experiment_02.surveys[0].id = "different_survey_name"
+        self.experiment_02.surveys[0].stations[0].location.latitude = 10
+        
+        
+    def test_update_from_new_experiment(self):
+        
+        self.mth5_obj.from_experiment(self.experiment_02, update=True)
+        
+        with self.subTest("new_survey"):
+            self.assertEqual(self.mth5_obj.survey_group.metadata.id,
+                             self.experiment_02.surveys[0].id)
+            
+        with self.subTest("new_location"):
+            st = self.mth5_obj.get_station("REW09")
+            self.assertEqual(
+                st.metadata.location.latitude,
+                self.experiment_02.surveys[0].stations[0].location.latitude)
+            
+    def tearDown(self):
+        self.mth5_obj.close_mth5()
+        self.fn.unlink()


### PR DESCRIPTION
This adds a keyword `update` to `MTH5.from_experiment`, which will update any metadata from the new experiment object.   Addresses issue #79 
Example use would be:

```
from mth5.mth5 import MTH5

m = MTH5()
m.open_mth5("existing_file.h5", "a")
m.from_experiment(new_experiment_object, update=True)

```

- [x] Add tests