### PR TITLE
change default initialize_mth5 to use append mode, issue #92

### DIFF
--- a/mth5/utils/helpers.py
+++ b/mth5/utils/helpers.py
@@ -4,7 +4,7 @@ from mth5.mth5 import MTH5
 from mth5.helpers import close_open_files
 
 
-def initialize_mth5(h5_path, mode="w", file_version="0.1.0"):
+def initialize_mth5(h5_path, mode="a", file_version="0.1.0"):
     """
     mth5 initializer for the case of writting files.
     Parameters


### PR DESCRIPTION
minor change - see issue #92...
basically with default "w" it is quite easy to lose data from an mth5 when working interactively.