### PR TITLE
Patch 123

### DIFF
--- a/tests/version_1/test_make_mth5.py
+++ b/tests/version_1/test_make_mth5.py
@@ -90,9 +90,7 @@ class TestMakeMTH5(unittest.TestCase):
         with self.subTest(name="stations"):
             self.assertListEqual(
                 sorted(self.stations),
-                sorted(
-                    list(set([ss.code for ss in inv.networks[0].stations]))
-                ),
+                sorted(list(set([ss.code for ss in inv.networks[0].stations]))),
             )
         with self.subTest(name="channels_CAS04"):
             self.assertListEqual(
@@ -211,9 +209,13 @@ class TestMakeMTH5(unittest.TestCase):
                 )
             for run in ["a", "b", "c"]:
                 for ch in ["ex", "ey", "hx", "hy", "hz"]:
+                    x = m.get_channel("NVR08", run, ch)
                     with self.subTest(name=f"has data NVR08.{run}.{ch}"):
-                        x = m.get_channel("NVR08", run, ch)
                         self.assertTrue(abs(x.hdf5_dataset[()].mean()) > 0)
+
+                    with self.subTest(name="filters"):
+                        self.assertTrue(x.metadata.filter.name != [])
+
             # with self.subTest("channel summary"):
 
             m.close_mth5()

--- a/tests/version_2/test_make_mth5.py
+++ b/tests/version_2/test_make_mth5.py
@@ -189,9 +189,13 @@ class TestMakeMTH5(unittest.TestCase):
                         self.assertTrue(abs(x.hdf5_dataset[()].mean()) > 0)
             for run in ["a", "b", "c"]:
                 for ch in ["ex", "ey", "hx", "hy", "hz"]:
+                    x = m.get_channel("NVR08", run, ch, "CONUS_South")
                     with self.subTest(name=f"has data NVR08.{run}.{ch}"):
-                        x = m.get_channel("NVR08", run, ch, "CONUS_South")
                         self.assertTrue(abs(x.hdf5_dataset[()].mean()) > 0)
+
+                    with self.subTest(name="filters"):
+                        self.assertTrue(x.metadata.filter.name != [])
+
             m.close_mth5()
             m.filename.unlink()
         except FDSNNoDataException as error:


### PR DESCRIPTION
When building an MTH5 from IRIS, some of the older data comes with information for only 1 run and thus the channel information was not being passed onto more runs.  This fixes that issue #123.

- [ ] In `make_mth5` when there is only one run, that metadata is passed to subsequent runs with an update `run_id` so that channel information is populated.
- [ ] Updated tests `/tests/version_1/test_make_mth5.py` and `/tests/version_2/test_make_mth5.py` to make sure the filter names are filled, maybe mute for this test cause it has multiple run information, but nonetheless tested it on the yellowstone data.