### PR TITLE
Adjust how metadata is initialized

### DIFF
--- a/mth5/groups/run.py
+++ b/mth5/groups/run.py
@@ -230,6 +230,9 @@ class RunGroup(BaseGroup):
     def metadata(self):
         """Overwrite get metadata to include channel information in the runs"""
 
+        if not self._has_read_metadata:
+            self.read_metadata()
+            self._has_read_metadata = True
         self._metadata.channels = []
         for ch in self.groups_list:
             meta_dict = dict(self.hdf5_group[ch].attrs)
@@ -429,7 +432,9 @@ class RunGroup(BaseGroup):
             channel_obj = self.get_channel(channel_name)
 
             if data is not None:
-                self.logger.debug(f"Replacing data with new shape {data.shape}")
+                self.logger.debug(
+                    f"Replacing data with new shape {data.shape}"
+                )
                 channel_obj.replace_dataset(data)
 
                 self.logger.debug("Updating metadata")
@@ -603,7 +608,7 @@ class RunGroup(BaseGroup):
             msg = f"Input must be a mth5.timeseries.RunTS object not {type(run_ts_obj)}"
             self.logger.error(msg)
             raise MTH5Error(msg)
-        self.metadata.update(run_ts_obj.run_metadata)
+        self._metadata.update(run_ts_obj.run_metadata)
 
         channels = []
 

--- a/mth5/groups/station.py
+++ b/mth5/groups/station.py
@@ -504,6 +504,10 @@ class StationGroup(BaseGroup):
     def metadata(self):
         """Overwrite get metadata to include run information in the station"""
 
+        if not self._has_read_metadata:
+            self.read_metadata()
+            self._has_read_metadata = True
+
         for key in self.groups_list:
             if key.lower() in [
                 name.lower() for name in self._default_subgroup_names

--- a/mth5/groups/survey.py
+++ b/mth5/groups/survey.py
@@ -147,7 +147,9 @@ class MasterSurveyGroup(BaseGroup):
         for survey in self.groups_list:
             survey_group = self.get_survey(survey)
             for station in survey_group.stations_group.groups_list:
-                station_group = survey_group.stations_group.get_station(station)
+                station_group = survey_group.stations_group.get_station(
+                    station
+                )
                 for run in station_group.groups_list:
                     run_group = station_group.get_run(run)
                     for ch in run_group.groups_list:
@@ -450,6 +452,10 @@ class SurveyGroup(BaseGroup):
     @BaseGroup.metadata.getter
     def metadata(self):
         """Overwrite get metadata to include station information in the survey"""
+
+        if not self._has_read_metadata:
+            self.read_metadata()
+            self._has_read_metadata = True
 
         try:
             if self.stations_group.groups_list != self._metadata.station_names:

--- a/tests/io/usgs_ascii/test_ascii_collection.py
+++ b/tests/io/usgs_ascii/test_ascii_collection.py
@@ -31,8 +31,8 @@ class TestUSGSasciiCollection(unittest.TestCase):
         )
 
         self.df = self.nc.to_dataframe([4])
+        self.df = self.df.fillna(0)
         self.runs = self.nc.get_runs([4])
-
         self.station = self.df.station.unique()[0]
 
     def test_file_path(self):
@@ -51,7 +51,7 @@ class TestUSGSasciiCollection(unittest.TestCase):
         )
 
     def test_df_shape(self):
-        self.assertEqual(self.df.shape, (2, 14))
+        self.assertEqual(self.df.shape, (2, 19))
 
     def test_df_types(self):
         self.df = self.nc._set_df_dtypes(self.df)
@@ -88,6 +88,7 @@ class TestUSGSasciiCollection(unittest.TestCase):
 
     def test_run_elements(self):
         for key, rdf in self.runs[self.station].items():
+            rdf = rdf.fillna(0)
             with self.subTest(key):
                 self.assertTrue(
                     (self.df[self.df.run == key].eq(rdf).all(axis=0).all())

--- a/tests/version_1/test_mth5.py
+++ b/tests/version_1/test_mth5.py
@@ -99,50 +99,50 @@ class TestMTH5(unittest.TestCase):
             )
 
     def test_remove_station(self):
-        self.mth5_obj.add_station("MT001")
-        self.mth5_obj.remove_station("MT001")
-        self.assertNotIn("MT001", self.mth5_obj.stations_group.groups_list)
+        self.mth5_obj.add_station("MT002")
+        self.mth5_obj.remove_station("MT002")
+        self.assertNotIn("MT002", self.mth5_obj.stations_group.groups_list)
 
     def test_get_station_fail(self):
         self.assertRaises(MTH5Error, self.mth5_obj.get_station, "MT010")
 
     def test_add_run(self):
-        new_station = self.mth5_obj.add_station("MT001")
-        new_run = new_station.add_run("MT001a")
+        new_station = self.mth5_obj.add_station("MT003")
+        new_run = new_station.add_run("MT003a")
         with self.subTest("groups list"):
-            self.assertIn("MT001a", new_station.groups_list)
+            self.assertIn("MT003a", new_station.groups_list)
         with self.subTest("isinstance RunGroup"):
             self.assertIsInstance(new_run, groups.RunGroup)
         with self.subTest("get run"):
-            rg = self.mth5_obj.get_run("MT001", "MT001a")
+            rg = self.mth5_obj.get_run("MT003", "MT003a")
             self.assertIsInstance(rg, groups.RunGroup)
 
         with self.subTest("check station metadata"):
-            self.assertListEqual(new_run.station_metadata.run_list, ["MT001a"])
+            self.assertListEqual(new_run.station_metadata.run_list, ["MT003a"])
         with self.subTest("check survey metadata"):
             self.assertListEqual(
-                new_run.survey_metadata.stations[0].run_list, ["MT001a"]
+                new_run.survey_metadata.stations[0].run_list, ["MT003a"]
             )
 
     def test_remove_run(self):
-        new_station = self.mth5_obj.add_station("MT001")
-        new_station.add_run("MT001a")
-        new_station.remove_run("MT001a")
-        self.assertNotIn("MT001a", new_station.groups_list)
+        new_station = self.mth5_obj.add_station("MT004")
+        new_station.add_run("MT004a")
+        new_station.remove_run("MT004a")
+        self.assertNotIn("MT004a", new_station.groups_list)
 
     def test_get_run_fail(self):
         self.assertRaises(MTH5Error, self.mth5_obj.get_run, "MT001", "MT002a")
 
     def test_add_channel(self):
-        new_station = self.mth5_obj.add_station("MT001")
-        new_run = new_station.add_run("MT001a")
+        new_station = self.mth5_obj.add_station("MT005")
+        new_run = new_station.add_run("MT005a")
         new_channel = new_run.add_channel("Ex", "electric", None)
         with self.subTest("groups list"):
             self.assertIn("ex", new_run.groups_list)
         with self.subTest("isinstance ElectricDataset"):
             self.assertIsInstance(new_channel, groups.ElectricDataset)
         with self.subTest("get channel"):
-            ch = self.mth5_obj.get_channel("MT001", "MT001a", "ex")
+            ch = self.mth5_obj.get_channel("MT005", "MT005a", "ex")
             self.assertIsInstance(ch, groups.ElectricDataset)
 
         with self.subTest("check run metadata"):
@@ -152,30 +152,30 @@ class TestMTH5(unittest.TestCase):
         with self.subTest("check station metadata"):
             self.assertListEqual(
                 new_channel.station_metadata.runs[
-                    "MT001a"
+                    "MT005a"
                 ].channels_recorded_all,
                 ["ex"],
             )
         with self.subTest("check survey metadata"):
             self.assertListEqual(
-                new_channel.survey_metadata.stations["MT001"]
-                .runs["MT001a"]
+                new_channel.survey_metadata.stations["MT005"]
+                .runs["MT005a"]
                 .channels_recorded_all,
                 ["ex"],
             )
 
     def test_remove_channel(self):
-        new_station = self.mth5_obj.add_station("MT001")
-        new_run = new_station.add_run("MT001a")
+        new_station = self.mth5_obj.add_station("MT006")
+        new_run = new_station.add_run("MT006a")
         new_run.add_channel("Ex", "electric", None)
         new_run.remove_channel("Ex")
         self.assertNotIn("ex", new_run.groups_list)
 
     def test_get_channel_fail(self):
-        new_station = self.mth5_obj.add_station("MT001")
-        new_station.add_run("MT001a")
+        new_station = self.mth5_obj.add_station("MT007")
+        new_station.add_run("MT007a")
         self.assertRaises(
-            MTH5Error, self.mth5_obj.get_channel, "MT001", "MT001a", "Ey"
+            MTH5Error, self.mth5_obj.get_channel, "MT007", "MT007a", "Ey"
         )
 
     def test_channel_mtts(self):

--- a/tests/version_1/test_mth5.py
+++ b/tests/version_1/test_mth5.py
@@ -85,6 +85,8 @@ class TestMTH5(unittest.TestCase):
 
     def test_add_station(self):
         new_station = self.mth5_obj.add_station("MT001")
+        with self.subTest("has_read_metadata"):
+            self.assertEqual(True, new_station._has_read_metadata)
         with self.subTest("groups list"):
             self.assertIn("MT001", self.mth5_obj.stations_group.groups_list)
         with self.subTest("isinstance StationGroup"):
@@ -109,6 +111,8 @@ class TestMTH5(unittest.TestCase):
     def test_add_run(self):
         new_station = self.mth5_obj.add_station("MT003")
         new_run = new_station.add_run("MT003a")
+        with self.subTest("has_read_metadata"):
+            self.assertEqual(True, new_run._has_read_metadata)
         with self.subTest("groups list"):
             self.assertIn("MT003a", new_station.groups_list)
         with self.subTest("isinstance RunGroup"):

--- a/tests/version_2/test_mth5.py
+++ b/tests/version_2/test_mth5.py
@@ -85,8 +85,27 @@ class TestMTH5(unittest.TestCase):
     def test_validation(self):
         self.assertEqual(self.mth5_obj.validate_file(), True)
 
+    def test_add_survey(self):
+        new_survey = self.mth5_obj.add_survey("other")
+        with self.subTest("has_read_metadata"):
+            self.assertEqual(True, new_survey._has_read_metadata)
+        with self.subTest(name="survey exists"):
+            self.assertIn("other", self.mth5_obj.surveys_group.groups_list)
+        with self.subTest(name="is survey group"):
+            self.assertIsInstance(new_survey, groups.SurveyGroup)
+
+    def test_remove_survey(self):
+        self.mth5_obj.add_survey("remove")
+        self.mth5_obj.remove_survey("remove")
+        self.assertNotIn("remove", self.mth5_obj.surveys_group.groups_list)
+
+    def test_get_survey_fail(self):
+        self.assertRaises(MTH5Error, self.mth5_obj.get_survey, "fail")
+
     def test_add_station(self):
         new_station = self.mth5_obj.add_station("MT001", survey="test")
+        with self.subTest("has_read_metadata"):
+            self.assertEqual(True, new_station._has_read_metadata)
         with self.subTest(name="station exists"):
             self.assertIn(
                 "MT001", self.survey_group.stations_group.groups_list
@@ -114,6 +133,8 @@ class TestMTH5(unittest.TestCase):
     def test_add_run(self):
         new_station = self.mth5_obj.add_station("MT003", survey="test")
         new_run = new_station.add_run("MT003a")
+        with self.subTest("has_read_metadata"):
+            self.assertEqual(True, new_run._has_read_metadata)
         with self.subTest("groups list"):
             self.assertIn("MT003a", new_station.groups_list)
         with self.subTest("isinstance RunGroup"):


### PR DESCRIPTION
Before when a file would open it would initialize all groups to read metadata, but that is slow because groups like survey, station, run read in the levels below them. This fix only reads the first time you want to get metadata from the group to speed it up.