### PR TITLE
Fix issue 171

### DIFF
--- a/mth5/timeseries/channel_ts.py
+++ b/mth5/timeseries/channel_ts.py
@@ -926,6 +926,7 @@ class ChannelTS:
                     f"Resetting ChannelTS.channel_metadata.sample_rate to {sample_rate}. "
                 )
             self.channel_metadata.sample_rate = sample_rate
+        self._sample_rate = sample_rate
         self._update_xarray_metadata()
 
     @property

--- a/mth5/timeseries/channel_ts.py
+++ b/mth5/timeseries/channel_ts.py
@@ -128,7 +128,8 @@ class ChannelTS:
         # input data
         if data is not None:
             self.ts = data
-        self._update_xarray_metadata()
+        else:
+            self._update_xarray_metadata()
 
         for key in list(kwargs.keys()):
             setattr(self, key, kwargs[key])

--- a/tests/timeseries/test_channel_ts.py
+++ b/tests/timeseries/test_channel_ts.py
@@ -2,7 +2,7 @@
 """
 Created on Fri Jan 22 12:32:55 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -364,7 +364,7 @@ class TestChannelTS(unittest.TestCase):
 
         with self.subTest(name="sample_interval"):
             self.assertEqual(self.ts.sample_interval, 1.0 / 16.0)
-        self.ts.sample_rate = 8
+        self.ts._sample_rate = 8
         with self.subTest("8"):
             self.assertEqual(self.ts.sample_rate, 8.0)
         with self.subTest("n_samples"):

--- a/tests/timeseries/test_channel_ts.py
+++ b/tests/timeseries/test_channel_ts.py
@@ -364,7 +364,7 @@ class TestChannelTS(unittest.TestCase):
 
         with self.subTest(name="sample_interval"):
             self.assertEqual(self.ts.sample_interval, 1.0 / 16.0)
-        self.ts._sample_rate = 8
+        self.ts.sample_rate = 8
         with self.subTest("8"):
             self.assertEqual(self.ts.sample_rate, 8.0)
         with self.subTest("n_samples"):


### PR DESCRIPTION
Notes are in issue #171.

Remaining things to be addressed:

- [x] modify @sample_rate.setter to update self._sample_rate
- [x] test_change_sample rate modified back to using the setter, rather than assigning self._sample_rate explicitly
- [x] Add direct assignment of self._sample_rate when it is packed in channel_metadata on init
  - [x]  as a dict
  - [x] as an mt_metadata object