### PR TITLE
Fix issue 191

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setup(
     keywords="mth5",
     name="mth5",
     packages=find_packages(include=["mth5", "mth5.*"]),
+    package_data={
+      'mth5': ['data/*.asc'],
+    },
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -1,0 +1,34 @@
+import mth5
+import pathlib
+import unittest
+
+# from loguru import logger
+
+
+class TestDataFolder(unittest.TestCase):
+    """ """
+
+    def setUp(self):
+        init_file = pathlib.Path(mth5.__file__)
+        self.data_folder = init_file.parent.joinpath("data")
+
+    def test_ascii_data_paths(self):
+        """
+        Make sure that the ascii data are where we think they are.
+
+        """
+
+        self.assertTrue(self.data_folder.exists())
+        file_paths = list(self.data_folder.glob("*asc"))
+        file_names = [x.name for x in file_paths]
+
+        assert "test1.asc" in file_names
+        assert "test2.asc" in file_names
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The ascii test data, although in the repo, were not showing up in the pip install _despite_ being in the manifest.

Found a discussion [here](https://stackoverflow.com/questions/7522250/how-to-include-package-data-with-setuptools-distutils/14159430#14159430) which led me to add the ascii files to setup.py via

```
package_data={
      'mth5': ['data/*.asc'],
    },
```