### PR TITLE
Optimize adding TF

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         conda install pytest=7.1.2
         conda install pytest-cov
         conda install pytest-subtests
-        pip install git+https://github.com/kujaku11/mt_metadata.git@add_pop
+        pip install git+https://github.com/kujaku11/mt_metadata.git@main
 
     - name: Install Our Package
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         conda install pytest=7.1.2
         conda install pytest-cov
         conda install pytest-subtests
-        pip install git+https://github.com/kujaku11/mt_metadata.git
+        pip install git+https://github.com/kujaku11/mt_metadata.git@add_pop
 
     - name: Install Our Package
       shell: bash

--- a/mth5/data/make_mth5_from_asc.py
+++ b/mth5/data/make_mth5_from_asc.py
@@ -166,7 +166,9 @@ def get_time_series_dataframe(
     # read in data
     df = pd.read_csv(run.raw_data_path, names=run.channels, sep="\s+")
     if len(df) == 0:
-        raise ValueError("Synthetic dataframe is empty. Check path")
+        raise ValueError(
+            f"Synthetic dataframe is empty. Check path {run.raw_data_path}"
+        )
 
     # Invert electric channels to fix phase swap due to modeling coordinates.
     df[df.columns[-2]] = -df[df.columns[-2]]  #  df["ex"] = -df["ex"]

--- a/mth5/data/make_mth5_from_asc.py
+++ b/mth5/data/make_mth5_from_asc.py
@@ -106,7 +106,7 @@ def create_run_ts_from_synthetic_run(
             channel_metadata = Magnetic()
             channel_metadata.units = "nanotesla"
             channel_metadata.component = col
-            channel_metadata.channel_number = i_col    # not required
+            channel_metadata.channel_number = i_col  # not required
             channel_metadata.sample_rate = run.run_metadata.sample_rate
             channel_metadata.time_period.start = run.start
             chts = ChannelTS(
@@ -140,7 +140,7 @@ def create_run_ts_from_synthetic_run(
 def get_time_series_dataframe(
     run: SyntheticRun,
     source_folder: Optional[Union[pathlib.Path, str]],
-    add_nan_values: Optional[bool] = False
+    add_nan_values: Optional[bool] = False,
 ) -> pd.DataFrame:
     """
     Returns time series data in a dataframe with columns named for EM field component.
@@ -165,6 +165,9 @@ def get_time_series_dataframe(
 
     # read in data
     df = pd.read_csv(run.raw_data_path, names=run.channels, sep="\s+")
+    print(df)
+    if len(df) == 0:
+        raise ValueError("Synthetic dataframe is empty. Check path")
 
     # Invert electric channels to fix phase swap due to modeling coordinates.
     df[df.columns[-2]] = -df[df.columns[-2]]  #  df["ex"] = -df["ex"]
@@ -251,7 +254,7 @@ def create_mth5_synthetic_file(
     try:
         target_folder.mkdir(exist_ok=True, parents=True)
     except OSError:
-        msg = "Aurora maybe installed on a read-only file system"
+        msg = "MTH5 maybe installed on a read-only file system"
         msg = f"{msg}: try setting target_path argument when calling create_mth5_synthetic_file"
         logger.error(msg)
 
@@ -282,7 +285,7 @@ def create_mth5_synthetic_file(
                 df = get_time_series_dataframe(
                     run=run,
                     source_folder=source_folder,
-                    add_nan_values=add_nan_values
+                    add_nan_values=add_nan_values,
                 )
 
                 # cast to run_ts
@@ -593,9 +596,7 @@ def _add_survey(m: MTH5, survey_metadata: Survey) -> None:
 
 
 def _update_mth5_path(
-    mth5_path: pathlib.Path,
-    add_nan_values: bool,
-    channel_nomenclature: str
+    mth5_path: pathlib.Path, add_nan_values: bool, channel_nomenclature: str
 ) -> pathlib.Path:
     """set name for output h5 file"""
     path_str = mth5_path.__str__()
@@ -611,9 +612,7 @@ def main(file_version="0.1.0"):
     create_test1_h5(file_version=file_version)
     create_test1_h5_with_nan(file_version=file_version)
     create_test2_h5(file_version=file_version)
-    create_test12rr_h5(
-        file_version=file_version, channel_nomenclature="lemi12"
-    )
+    create_test12rr_h5(file_version=file_version, channel_nomenclature="lemi12")
     create_test3_h5(file_version=file_version)
     create_test4_h5(file_version=file_version)
 

--- a/mth5/data/make_mth5_from_asc.py
+++ b/mth5/data/make_mth5_from_asc.py
@@ -165,7 +165,6 @@ def get_time_series_dataframe(
 
     # read in data
     df = pd.read_csv(run.raw_data_path, names=run.channels, sep="\s+")
-    print(df)
     if len(df) == 0:
         raise ValueError("Synthetic dataframe is empty. Check path")
 

--- a/mth5/groups/station.py
+++ b/mth5/groups/station.py
@@ -183,17 +183,38 @@ class MasterStationGroup(BaseGroup):
         :rtype: TYPE
 
         """
-        st_list = []
-        for key, group in self.hdf5_group.items():
-            entry = {
-                "station": key,
+
+        def _get_entry(group):
+            return {
+                "station": group.attrs["id"],
                 "start": group.attrs["time_period.start"],
                 "end": group.attrs["time_period.end"],
                 "latitude": group.attrs["location.latitude"],
                 "longitude": group.attrs["location.longitude"],
             }
-            st_list.append(entry)
 
+        def _recursive_get_station_entry(group, entry_list=[]):
+            """
+            method to get station entry
+            """
+
+            if isinstance(group, h5py._hl.group.Group):
+                try:
+                    group_type = group.attrs["mth5_type"].lower()
+                    if group_type in ["station"]:
+                        entry_list.append(_get_entry(group))
+                    elif group_type in ["masterstation"]:
+                        for key, node in group.items():
+                            entry_list = _recursive_get_station_entry(
+                                node, entry_list
+                            )
+
+                except KeyError:
+                    pass
+            return entry_list
+
+        st_list = []
+        st_list = _recursive_get_station_entry(self.hdf5_group, st_list)
         df = pd.DataFrame(st_list)
         if len(df):
             try:

--- a/mth5/groups/survey.py
+++ b/mth5/groups/survey.py
@@ -484,6 +484,7 @@ class SurveyGroup(BaseGroup):
                 value = to_numpy_type(value)
                 self.logger.debug(f"wrote metadata {key} = {value}")
                 self.hdf5_group.attrs.create(key, value)
+            self._has_read_metadata = True
         except KeyError as key_error:
             if "no write intent" in str(key_error):
                 self.logger.warning(

--- a/mth5/groups/survey.py
+++ b/mth5/groups/survey.py
@@ -518,7 +518,9 @@ class SurveyGroup(BaseGroup):
         if survey_dict:
             self.metadata.from_dict(survey_dict, skip_none=True)
 
-        if not len(station_summary):  # if station info is empty df, skip parsing
+        if not len(
+            station_summary
+        ):  # if station info is empty df, skip parsing
             self.write_metadata()
             return
 
@@ -541,4 +543,6 @@ class SurveyGroup(BaseGroup):
             station_summary.longitude.max()
         )
 
+        # metadata by default comes with stations and runs, need to remove those
+        # before writing the metadata.
         self.write_metadata()

--- a/mth5/mth5.py
+++ b/mth5/mth5.py
@@ -1480,7 +1480,7 @@ class MTH5:
             .remove_channel(channel_name)
         )
 
-    def add_transfer_function(self, tf_object):
+    def add_transfer_function(self, tf_object, update_metadata=True):
         """
         Add a transfer function
         :param tf_object: DESCRIPTION
@@ -1563,8 +1563,8 @@ class MTH5:
             station_group = survey_group.stations_group.get_station(
                 tf_object.station_metadata.id
             )
-            station_group.metadata.update(tf_object.to_ts_station_metadata())
-            station_group.write_metadata()
+            # station_group.metadata.update(tf_object.to_ts_station_metadata())
+            # station_group.write_metadata()
         except MTH5Error:
             station_group = survey_group.stations_group.add_station(
                 tf_object.station_metadata.id,
@@ -1619,7 +1619,8 @@ class MTH5:
                 )
             )
 
-        survey_group.update_metadata()
+        if update_metadata:
+            survey_group.update_metadata()
         return tf_group
 
     def get_transfer_function(self, station_id, tf_id, survey=None):

--- a/mth5/mth5.py
+++ b/mth5/mth5.py
@@ -368,7 +368,9 @@ class MTH5:
             self.logger.error(msg)
             raise ValueError(msg)
         if value not in ACCEPTABLE_FILE_TYPES:
-            msg = f"Input file.type is not valid, must be {ACCEPTABLE_FILE_TYPES}"
+            msg = (
+                f"Input file.type is not valid, must be {ACCEPTABLE_FILE_TYPES}"
+            )
             self.logger.error(msg)
             raise ValueError(msg)
         self.__file_type = value
@@ -581,7 +583,7 @@ class MTH5:
                 station_list += sg.stations_group.groups_list
             return station_list
 
-    def open_mth5(self, filename=None, mode="a"):
+    def open_mth5(self, filename=None, mode="a", **kwargs):
         """
         open an mth5 file
 
@@ -620,14 +622,18 @@ class MTH5:
                     )
                     self.logger.exception(msg)
             elif mode in ["a", "w-", "x", "r+"]:
-                self.__hdf5_obj = h5py.File(self.__filename, mode=mode)
+                self.__hdf5_obj = h5py.File(
+                    self.__filename, mode=mode, **kwargs
+                )
                 self._set_default_groups()
                 if not self.validate_file():
                     msg = "Input file is not a valid MTH5 file"
                     self.logger.error(msg)
                     raise MTH5Error(msg)
             elif mode in ["r"]:
-                self.__hdf5_obj = h5py.File(self.__filename, mode=mode)
+                self.__hdf5_obj = h5py.File(
+                    self.__filename, mode=mode, **kwargs
+                )
                 self._set_default_groups()
                 self.validate_file()
             else:
@@ -636,7 +642,7 @@ class MTH5:
                 raise MTH5Error(msg)
         else:
             if mode in ["a", "w", "w-", "x"]:
-                self._initialize_file(mode=mode)
+                self._initialize_file(mode=mode, **kwargs)
             else:
                 msg = f"Cannot open new file in mode {mode} "
                 self.logger.error(msg)
@@ -646,7 +652,7 @@ class MTH5:
             self._initialize_summary()
         return self
 
-    def _initialize_file(self, mode="w"):
+    def _initialize_file(self, mode="w", **kwargs):
         """
         Initialize the default groups for the file
 
@@ -655,7 +661,7 @@ class MTH5:
 
         """
         # open an hdf5 file
-        self.__hdf5_obj = h5py.File(self.__filename, mode)
+        self.__hdf5_obj = h5py.File(self.__filename, mode, **kwargs)
 
         # write general metadata
         self.__hdf5_obj.attrs.update(self.file_attributes)
@@ -1439,9 +1445,7 @@ class MTH5:
                 f"Could not find channel, {run_path}/{channel_name}"
             )
 
-    def remove_channel(
-        self, station_name, run_name, channel_name, survey=None
-    ):
+    def remove_channel(self, station_name, run_name, channel_name, survey=None):
         """
         Convenience function to remove a channel using
         ``mth5.stations_group.get_station().get_run().remove_channel()``

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -83,11 +83,11 @@ class TestMetadataValuesSetCorrect(unittest.TestCase):
 
     def make_run_summary(self):
         mth5_path = self.make_mth5()
-        m = MTH5()
-        m.open_mth5(mth5_path)
-        station_id = m.station_list[0]  # station should be named "test3"
-        self.assertTrue(station_id == "test3")
-        station_obj = m.get_station(station_id)
+        with MTH5() as m:
+            m = m.open_mth5(mth5_path)
+            station_id = m.station_list[0]  # station should be named "test3"
+            self.assertTrue(station_id == "test3")
+            station_obj = m.get_station(station_id)
         return station_obj.run_summary
 
     def test_start_times_correct(self):

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -5,6 +5,7 @@ import pathlib
 import unittest
 
 from mth5.data.make_mth5_from_asc import create_test1_h5
+
 # from mth5.data.make_mth5_from_asc import create_test1_h5_with_nan
 from mth5.data.make_mth5_from_asc import create_test12rr_h5
 from mth5.data.make_mth5_from_asc import create_test2_h5
@@ -43,6 +44,7 @@ class TestDataFolder(unittest.TestCase):
         assert "test1.asc" in file_names
         assert "test2.asc" in file_names
 
+
 class TestMakeSyntheticMTH5(unittest.TestCase):
     """
     create_test1_h5(file_version=file_version)
@@ -59,6 +61,7 @@ class TestMakeSyntheticMTH5(unittest.TestCase):
     def test_make_more_mth5s(self):
         create_test1_h5(file_version="0.1.0", source_folder=SOURCE_PATH)
 
+
 class TestMetadataValuesSetCorrect(unittest.TestCase):
     """
     Tests setting of start time as per aurora issue #188
@@ -73,7 +76,9 @@ class TestMetadataValuesSetCorrect(unittest.TestCase):
 
     def make_mth5(self):
         close_open_files()
-        mth5_path = create_test3_h5(force_make_mth5=self.remake_mth5_for_each_test)
+        mth5_path = create_test3_h5(
+            force_make_mth5=self.remake_mth5_for_each_test
+        )
         return mth5_path
 
     def make_run_summary(self):
@@ -93,13 +98,15 @@ class TestMetadataValuesSetCorrect(unittest.TestCase):
                 run_summary_df.id == run.run_metadata.id
             ].iloc[0]
             expected_start = run.run_metadata.time_period.start
-            assert summary_row.start == pd.Timestamp(expected_start).tz_convert(None)
+            with self.subTest(run):
+                self.assertEqual(
+                    summary_row.start,
+                    pd.Timestamp(expected_start).tz_convert(None),
+                )
 
 
-def main():
-#    TestMetadataValuesSetCorrect()
-    unittest.main()
-
-
+# =============================================================================
+# Run
+# =============================================================================
 if __name__ == "__main__":
-    main()
+    unittest.main()

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -88,7 +88,7 @@ class TestMetadataValuesSetCorrect(unittest.TestCase):
             station_id = m.station_list[0]  # station should be named "test3"
             self.assertTrue(station_id == "test3")
             station_obj = m.get_station(station_id)
-        return station_obj.run_summary
+            return station_obj.run_summary
 
     def test_start_times_correct(self):
         run_summary_df = self.make_run_summary()

--- a/tests/version_1/test_mth5.py
+++ b/tests/version_1/test_mth5.py
@@ -66,8 +66,7 @@ class TestMTH5(unittest.TestCase):
     def test_default_group_names(self):
         groups = sorted(self.mth5_obj.survey_group.groups_list)
         defaults = sorted(
-            self.mth5_obj._default_subgroup_names
-            + _default_table_names()
+            self.mth5_obj._default_subgroup_names + _default_table_names()
         )
 
         self.assertListEqual(defaults, groups)
@@ -85,14 +84,24 @@ class TestMTH5(unittest.TestCase):
         self.assertEqual(self.mth5_obj.validate_file(), True)
 
     def test_set_survey_metadata_attr(self):
-        """ Test that we can change a value in the survey metadata and this is written to mth5"""
+        """Test that we can change a value in the survey metadata and
+        this is written to mth5
+        """
         survey_metadata = self.mth5_obj.survey_group.metadata
-        assert survey_metadata.id is None
-        new_survey_id = "MT Survey"
-        survey_metadata.id = new_survey_id
-        assert survey_metadata.id == new_survey_id
-        self.mth5_obj.survey_group.update_metadata(survey_metadata.to_dict())
-        assert self.mth5_obj.survey_group.metadata.id == new_survey_id
+        with self.subTest("id None"):
+            self.assertEqual(survey_metadata.id, None)
+
+        with self.subTest("id set"):
+            new_survey_id = "MT Survey"
+            survey_metadata.id = new_survey_id
+            self.assertEqual(survey_metadata.id, new_survey_id)
+        with self.subTest("metadata update"):
+            self.mth5_obj.survey_group.update_metadata(
+                survey_metadata.to_dict()
+            )
+            self.assertEqual(
+                self.mth5_obj.survey_group.metadata.id, new_survey_id
+            )
 
     def test_add_station(self):
         new_station = self.mth5_obj.add_station("MT001")


### PR DESCRIPTION
There is a slowdown in adding transfer functions, that mainly seems to do with updating the survey metadata each time a new transfer function is added.  Add options to no update each time and just update at the end.  This PR helps speed up things to resolve issue https://github.com/MTgeophysics/mtpy-v2/issues/44.  

- [x] Speed up recursive search for station summary in `mth5/groups/station`
- [x] Overwrite `write_metadata` in `mth5/groups/survey.SurveyGroup` this needs to be done because the `metadata` property fills in the entire survey metadata including stations, runs, channels.  However, the survey metadata is just for the survey, so need to override what metadata is being written.
- [x] In `mth5/groups/transfer_function` add `update_metadata` keyword to not update the survey metadata when a transfer object is added.  Propogate that keyword to other functions.
- [x] Added kwargs to be passed to `mth5/mth5.MTH5.open_mth5` so that the user can add other options for opening an h5 file.