### PR TITLE
Resolve SyntaxWarnings in Python 3.12 and above for invalid escape sequences

### DIFF
--- a/mth5/io/lemi/lemi424.py
+++ b/mth5/io/lemi/lemi424.py
@@ -2,7 +2,7 @@
 """
 Created on Tue May 11 15:31:31 2021
 
-:copyright: 
+:copyright:
     Jared Peacock (jpeacock@usgs.gov)
 
 :license: MIT
@@ -446,7 +446,7 @@ class LEMI424:
                 self.read_metadata()
                 data = pd.read_csv(
                     self.fn,
-                    delimiter="\s+",
+                    delimiter=r"\s+",
                     names=self.file_column_names,
                     dtype=self.dtypes,
                     usecols=(
@@ -499,7 +499,7 @@ class LEMI424:
             dfs = list(
                 pd.read_csv(
                     self.fn,
-                    delimiter="\s+",
+                    delimiter=r"\s+",
                     names=self.file_column_names,
                     dtype=self.dtypes,
                     parse_dates={
@@ -533,7 +533,7 @@ class LEMI424:
             st = MTime().now()
             self.data = pd.read_csv(
                 self.fn,
-                delimiter="\s+",
+                delimiter=r"\s+",
                 names=self.file_column_names,
                 dtype=self.dtypes,
                 parse_dates={

--- a/mth5/io/lemi/lemi424.py
+++ b/mth5/io/lemi/lemi424.py
@@ -576,7 +576,7 @@ class LEMI424:
 
         self.data = pd.read_csv(
             lines,
-            delimiter="\s+",
+            delimiter=r"\s+",
             names=self.file_column_names,
             dtype=self.dtypes,
             parse_dates={


### PR DESCRIPTION
Python 3.12 now issues SyntaxWarnings for invalid escape sequences.   There were some regexes being passed as delimiter values to pd.read_csv(), which triggered a few of these warnings.   Passing them as raw strings disables the invalid escape sequence checks and resolves the warnings without affecting functionality.