### PR TITLE
HOT FIX: importing scipy, to use scipy.stats

### DIFF
--- a/mth5/timeseries/channel_ts.py
+++ b/mth5/timeseries/channel_ts.py
@@ -25,6 +25,7 @@ import pandas as pd
 import xarray as xr
 from loguru import logger
 from scipy import signal
+import scipy
 
 import mt_metadata.timeseries as metadata
 from mt_metadata.timeseries.filters import ChannelResponse


### PR DESCRIPTION
In previous PR #246 It seems that we forgot to import scipy to be able to use scipy.stats in chanel_ts.py. I did not realize you prefer to use: "from scipy import signal" instead of importing scipy and then using scipy.signal. To do the hot fix I though of using the same pattern (e.g., from scipy import stats), but it could be confusing considering the uses of obspy.stats and similar, so I opted to just import scipy. Let me know if you prefer any other convention such as from scipy import stats as scistats. 


This is related to Issue #257 