### PR TITLE
Some changes to synthetic data examples and creation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,14 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+#        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
     - name: Setup Conda
       uses: s-weigand/setup-conda@v1.0.7
       with:
-        update-conda: true
+        update-conda: false
         python-version: ${{ matrix.python-version }}
 
     - name: Install Env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         python --version
         conda create -n mth5-test python=${{ matrix.python-version }}
         source activate mth5-test
-        conda install pytest-7.4.4
+        conda install pytest=7.4.4
         conda install pytest-cov
         conda install pytest-subtests
         pip install git+https://github.com/kujaku11/mt_metadata.git@features

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         python --version
         conda create -n mth5-test python=${{ matrix.python-version }}
         source activate mth5-test
-        conda install pytest=7.4.4
+        conda install pytest=7.3
         conda install pytest-cov
         conda install pytest-subtests
         pip install git+https://github.com/kujaku11/mt_metadata.git@features

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Conda
-      uses: s-weigand/setup-conda@v1.2.1
+      uses: s-weigand/setup-conda@v1.2.2
       with:
         update-conda: false
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Conda
-      uses: s-weigand/setup-conda@v1.2.2
+      uses: s-weigand/setup-conda@v1.2.3
       with:
         update-conda: false
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
 #        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
         python --version
         conda create -n mth5-test python=${{ matrix.python-version }}
         source activate mth5-test
-        conda install pytest=7.3
+        conda install pytest
         conda install pytest-cov
         conda install pytest-subtests
         pip install git+https://github.com/kujaku11/mt_metadata.git@features

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Conda
-      uses: s-weigand/setup-conda@v1.0.7
+      uses: s-weigand/setup-conda@v1.2.3
       with:
-        update-conda: false
+        update-conda: true
         python-version: ${{ matrix.python-version }}
 
     - name: Install Env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Conda
-      uses: s-weigand/setup-conda@v1.2.3
+      uses: s-weigand/setup-conda@v1.0.7
       with:
         update-conda: true
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         python --version
         conda create -n mth5-test python=${{ matrix.python-version }}
         source activate mth5-test
-        conda install pytest # =7.1.2
+        conda install pytest-7.4.4
         conda install pytest-cov
         conda install pytest-subtests
         pip install git+https://github.com/kujaku11/mt_metadata.git@features

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Conda
-      uses: s-weigand/setup-conda@v1.2.3
+      uses: s-weigand/setup-conda@v1.0.7
       with:
         update-conda: false
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
 #        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
         python --version
         conda create -n mth5-test python=${{ matrix.python-version }}
         source activate mth5-test
-        conda install pytest
+        conda install pytest=7.3
         conda install pytest-cov
         conda install pytest-subtests
         pip install git+https://github.com/kujaku11/mt_metadata.git@features

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         python --version
         conda create -n mth5-test python=${{ matrix.python-version }}
         source activate mth5-test
-        conda install pytest=7.1.2
+        conda install pytest # =7.1.2
         conda install pytest-cov
         conda install pytest-subtests
         pip install git+https://github.com/kujaku11/mt_metadata.git@features

--- a/mth5/data/make_mth5_from_asc.py
+++ b/mth5/data/make_mth5_from_asc.py
@@ -104,6 +104,10 @@ def create_run_ts_from_synthetic_run(
         elif col in channel_nomenclature_obj.hx_hy_hz:
             channel_metadata = Magnetic()
             channel_metadata.units = "nanotesla"
+        else:
+            msg = f"column {col} not in channel_nomenclature_obj {channel_nomenclature_obj}"
+            logger.error(msg)
+            raise ValueError(msg)
 
         channel_metadata.component = col
         channel_metadata.channel_number = i_col  # not required

--- a/mth5/data/make_mth5_from_asc.py
+++ b/mth5/data/make_mth5_from_asc.py
@@ -73,7 +73,7 @@ MTH5_PATH = synthetic_test_paths.mth5_path
 def create_run_ts_from_synthetic_run(
     run: SyntheticRun,
     df: pd.DataFrame,
-    channel_nomenclature_obj: ChannelNomenclature
+    channel_nomenclature: ChannelNomenclature
 ) -> RunTS:
     """
     Loop over channels of synthetic data in df and make ChannelTS objects.
@@ -96,14 +96,14 @@ def create_run_ts_from_synthetic_run(
     for i_col, col in enumerate(df.columns):
 
         data = df[col].values
-        if col in channel_nomenclature_obj.ex_ey:
+        if col in channel_nomenclature.ex_ey:
             channel_metadata = Electric()
             channel_metadata.units = "millivolts per kilometer"
-        elif col in channel_nomenclature_obj.hx_hy_hz:
+        elif col in channel_nomenclature.hx_hy_hz:
             channel_metadata = Magnetic()
             channel_metadata.units = "nanotesla"
         else:
-            msg = f"column {col} not in channel_nomenclature_obj {channel_nomenclature_obj}"
+            msg = f"column {col} not in channel_nomenclature {channel_nomenclature}"
             logger.error(msg)
             raise ValueError(msg)
 
@@ -119,9 +119,9 @@ def create_run_ts_from_synthetic_run(
 
         # Set dipole properties
         # (Not sure how to pass this in channel_metadata when intializing)
-        if col in channel_nomenclature_obj.ex_ey:
+        if col in channel_nomenclature.ex_ey:
             chts.channel_metadata.dipole_length = 50
-            if col == channel_nomenclature_obj.ey:
+            if col == channel_nomenclature.ey:
                 chts.channel_metadata.measurement_azimuth = 90.0
 
         # Set filters
@@ -225,7 +225,7 @@ def create_mth5_synthetic_file(
     :rtype: mth5_path: pathlib.Path
 
     """
-    nomenclatures = [x.channel_nomenclature_obj.keyword for x in station_cfgs]
+    nomenclatures = [x.channel_nomenclature.keyword for x in station_cfgs]
     unconventional_nomenclatures = [x for x in nomenclatures if x.lower() != "default"]
     if unconventional_nomenclatures:
         nomenclature_str = "_".join(unconventional_nomenclatures)
@@ -280,8 +280,9 @@ def create_mth5_synthetic_file(
                 #  synthetic_run.to_run_ts(df)
                 # but channel types for each column name must come from the Station level.
                 runts = create_run_ts_from_synthetic_run(
-                    run, df,
-                    channel_nomenclature_obj=station_cfg.channel_nomenclature_obj
+                    run,
+                    df,
+                    channel_nomenclature=station_cfg.channel_nomenclature
                 )
                 runts.station_metadata.id = station_group.metadata.id
 

--- a/mth5/data/make_mth5_from_asc.py
+++ b/mth5/data/make_mth5_from_asc.py
@@ -74,7 +74,7 @@ def create_run_ts_from_synthetic_run(
     run: SyntheticRun,
     df: pd.DataFrame,
     channel_nomenclature: SupportedNomenclature = "default"
-):
+) -> RunTS:
     """
     Loop over channels of synthetic data in df and make ChannelTS objects.
 
@@ -137,8 +137,6 @@ def create_run_ts_from_synthetic_run(
     # make a RunTS object
     runts = RunTS(array_list=ch_list, run_metadata=run.run_metadata)
 
-    # add in metadata
-    # runts.run_metadata.id = run.run_metadata.id
     return runts
 
 
@@ -194,7 +192,6 @@ def create_mth5_synthetic_file(
     plot: bool = False,
     add_nan_values: bool = False,
     file_version: Literal["0.1.0", "0.2.0"] = "0.1.0",
-    channel_nomenclature: SupportedNomenclature = "default",
     force_make_mth5: bool = True,
     survey_metadata: Optional[Survey] = None,
 ):
@@ -221,10 +218,6 @@ def create_mth5_synthetic_file(
     :type add_nan_values: bool
     :param file_version: One of the supported mth5 file versions.  This is the version of mth5 to create.
     :type file_version: Literal["0.1.0", "0.2.0"] = "0.1.0",
-    :param channel_nomenclature: Keyword corresponding to channel nomenclature mapping in CHANNEL_MAPS variable,
-    for example ['default', 'lemi12', 'lemi34', 'phoenix123']
-    A full list is in mt_metadata/transfer_functions/processing/aurora/standards/channel_nomenclatures.json
-    :type channel_nomenclature: SupportedNomenclature
     :param force_make_mth5: If set to true, the file will be made, even if it already exists.
     If false, and file already exists, skip the make job.
     :type force_make_mth5: bool
@@ -234,11 +227,20 @@ def create_mth5_synthetic_file(
     :rtype: mth5_path: pathlib.Path
 
     """
+    nomenclatures = [x.channel_nomenclature_obj.keyword for x in station_cfgs]
+    unconventional_nomenclatures = [x for x in nomenclatures if x.lower() != "default"]
+    if unconventional_nomenclatures:
+        nomenclature_str = "_".join(unconventional_nomenclatures)
+    else:
+        nomenclature_str = ""
 
+    # determine the path to the file that will be created
     target_folder = _get_target_folder(target_folder=target_folder)
     mth5_path = target_folder.joinpath(mth5_name)
     mth5_path = _update_mth5_path(
-        mth5_path, add_nan_values, channel_nomenclature
+        mth5_path,
+        add_nan_values,
+        channel_nomenclature=nomenclature_str
     )
 
     # Only create file if needed
@@ -276,8 +278,11 @@ def create_mth5_synthetic_file(
                 #  (They don't belong in get_time_Series_dataframe()
 
                 # cast to run_ts
+                # TODO: This could be
+                #  synthetic_run.to_run_ts(df)
+                # but channel types for each column name must come from the Station level.
                 runts = create_run_ts_from_synthetic_run(
-                    run, df, channel_nomenclature=channel_nomenclature
+                    run, df, channel_nomenclature=station_cfg.channel_nomenclature
                 )
                 runts.station_metadata.id = station_group.metadata.id
 
@@ -361,12 +366,12 @@ def create_test1_h5(
     station_params = [
         station_01_params,
     ]
+
     mth5_path = create_mth5_synthetic_file(
         station_params,
         mth5_name,
         plot=False,
         file_version=file_version,
-        channel_nomenclature=channel_nomenclature,
         target_folder=target_folder,
         source_folder=source_folder,
         force_make_mth5=force_make_mth5,
@@ -497,7 +502,6 @@ def create_test12rr_h5(
         station_params,
         mth5_name,
         file_version=file_version,
-        channel_nomenclature=channel_nomenclature,
         target_folder=target_folder,
         source_folder=source_folder,
         force_make_mth5=force_make_mth5,
@@ -587,7 +591,6 @@ def create_test4_h5(
         station_04_params.mth5_name,
         plot=False,
         file_version=file_version,
-        channel_nomenclature=channel_nomenclature,
         target_folder=target_folder,
         source_folder=source_folder,
         force_make_mth5=force_make_mth5,
@@ -619,13 +622,27 @@ def _update_mth5_path(
     add_nan_values: bool,
     channel_nomenclature: str
 ) -> pathlib.Path:
-    """ Modify the name of output h5 file based on wheter or not nan-data are included
-     as well as channel_nomenclature if not default. """
+    """
+
+    Modify the name of output h5 file based on wheter or not nan-data are included
+     as well as channel_nomenclature if not default for all stations.
+
+    :param mth5_path:
+    :param add_nan_values:
+    :param channel_nomenclature: designator for the channel nomenclatures in the mth5
+    :type channel_nomenclature: str
+
+    :return: TODO
+    :rtype: pathlib.Path
+
+    """
+
     path_str = mth5_path.__str__()
     if add_nan_values:
         path_str = path_str.replace(".h5", "_nan.h5")
-    if channel_nomenclature != "default":
-        path_str = path_str.replace(".h5", f"_{channel_nomenclature}.h5")
+    if channel_nomenclature:
+        if channel_nomenclature != "default":
+            path_str = path_str.replace(".h5", f"_{channel_nomenclature}.h5")
     return pathlib.Path(path_str)
 
 

--- a/mth5/data/make_mth5_from_asc.py
+++ b/mth5/data/make_mth5_from_asc.py
@@ -73,7 +73,7 @@ MTH5_PATH = synthetic_test_paths.mth5_path
 def create_run_ts_from_synthetic_run(
     run: SyntheticRun,
     df: pd.DataFrame,
-    channel_nomenclature: SupportedNomenclature = "default"
+    channel_nomenclature_obj: ChannelNomenclature
 ) -> RunTS:
     """
     Loop over channels of synthetic data in df and make ChannelTS objects.
@@ -92,8 +92,6 @@ def create_run_ts_from_synthetic_run(
 
     """
 
-    channel_nomenclature_obj = ChannelNomenclature()
-    channel_nomenclature_obj.keyword = channel_nomenclature
     ch_list = []
     for i_col, col in enumerate(df.columns):
 
@@ -282,7 +280,8 @@ def create_mth5_synthetic_file(
                 #  synthetic_run.to_run_ts(df)
                 # but channel types for each column name must come from the Station level.
                 runts = create_run_ts_from_synthetic_run(
-                    run, df, channel_nomenclature=station_cfg.channel_nomenclature
+                    run, df,
+                    channel_nomenclature_obj=station_cfg.channel_nomenclature_obj
                 )
                 runts.station_metadata.id = station_group.metadata.id
 

--- a/mth5/data/station_config.py
+++ b/mth5/data/station_config.py
@@ -84,8 +84,8 @@ class SyntheticRun(object):
         self,
         id: str,
         sample_rate: float,
+        channels: List[str],
         raw_data_path: Optional[Union[str, pathlib.Path]] = None,
-        channels: Optional[list] = None,
         noise_scalars: Optional[dict] = None,
         nan_indices: Optional[dict] = None,
         filters: Optional[dict] = None,
@@ -100,10 +100,10 @@ class SyntheticRun(object):
         :type id: str
         :param sample_rate: sample rate of the time series in Hz.
         :type sample_rate: float
+        :param channels: the channel names to include in the run.
+        :type channels: List[str]
         :param raw_data_path: Path to ascii data source
         :type raw_data_path: Union[str, pathlib.Path, None]
-        :param channels: the channel names to include in the run.
-        :type channels: Union[list, None]
         :param noise_scalars: Keys are channels, values are scale factors for noise to add
         :type noise_scalars: Union[dict, None]
         :param nan_indices: Keys are channels, values lists.  List elements are pairs of (index, num_nan_to_add)
@@ -116,7 +116,7 @@ class SyntheticRun(object):
          Added 2025 to try to allow more general data to be cast to mth5
         :type timeseries_dataframe: Optional[pd.DataFrame] = None
         :param data_source: Keyword to tell if data are a legacy EMTF ASCII file
-        :param data_source: Keyword to tell if data are a legacy EMTF ASCII file
+        :type data_source: str
 
         """
         run_metadata = Run()
@@ -131,11 +131,8 @@ class SyntheticRun(object):
             self.data_source = data_source
             self.raw_data_path = raw_data_path
 
-        # # set channel names
-        if channels is None:
-            self.channels = list(channel_map.values())
-        else:
-            self.channels = channels
+        # set channel names
+        self.channels = channels
 
         # Set scale factors for adding noise to individual channels
         self.noise_scalars = noise_scalars

--- a/mth5/data/station_config.py
+++ b/mth5/data/station_config.py
@@ -15,7 +15,10 @@ Station level: mt_metadata Station() object with station info.
   - the `id` field (name of the station) is required.
   - other station metadata can be added
   - channel_nomenclature
-
+    - The channel_nomenclature was previously stored at the run level.  It makes more sense to store
+     this info at the station level, as the only reason the nomenclature would change (that I can
+     think of) would be if the acquistion system changed, in which case it would make the most
+     sense to initialize a new station object.
 
 Run level: 'columns', :channel names as a list; ["hx", "hy", "hz", "ex", "ey"]
 Run level: 'raw_data_path', Path to ascii data source
@@ -25,11 +28,6 @@ Run level: 'filters', dict of filters keyed by columns
 Run level: 'run_id', name of the run
 Run level: 'sample_rate', 1.0
 
-2025-02-12:
- - The channel_nomenclature was previously stored at the run level.  It makes more sense to store
- this info at the station level, as the only reason the nomenclature would change (that I can
- think of) would be if the acquistion system changed, in which case it would make the most
- sense to initialize a new station object.
 
 """
 import pathlib
@@ -222,16 +220,17 @@ class SyntheticStation(object):
         self.runs = []
         self.mth5_name = mth5_name
         self.channel_nomenclature_keyword = channel_nomenclature_keyword
-        self._channel_nomenclature_obj = None  # TODO: rename to channel_nomenclature
+        self._channel_nomenclature = None
 
-        self.station_metadata.channels_recorded = self.channel_nomenclature_obj.channels
+        self.station_metadata.channels_recorded = self.channel_nomenclature.channels
 
     @property
-    def channel_nomenclature_obj(self):  # TODO: rename to channel_nomenclature
-        if self._channel_nomenclature_obj is None:
-            self._channel_nomenclature_obj = ChannelNomenclature(
-                keyword=self.channel_nomenclature_keyword)
-        return self._channel_nomenclature_obj
+    def channel_nomenclature(self):
+        if self._channel_nomenclature is None:
+            self._channel_nomenclature = ChannelNomenclature(
+                keyword=self.channel_nomenclature_keyword
+            )
+        return self._channel_nomenclature
 
 
 def make_station_01(channel_nomenclature: SupportedNomenclature = "default") -> SyntheticStation:
@@ -260,7 +259,7 @@ def make_station_01(channel_nomenclature: SupportedNomenclature = "default") -> 
     run_001 = SyntheticRun(
         id="001",
         sample_rate=1.0,
-        channels = station.channel_nomenclature_obj.channels,
+        channels = station.channel_nomenclature.channels,
         raw_data_path=ASCII_DATA_PATH.joinpath("test1.asc"),
         start=None,
     )
@@ -269,9 +268,9 @@ def make_station_01(channel_nomenclature: SupportedNomenclature = "default") -> 
     nan_indices = {}
     for ch in run_001.channels:
         nan_indices[ch] = []
-        if ch == station.channel_nomenclature_obj.hx:
+        if ch == station.channel_nomenclature.hx:
             nan_indices[ch].append([11, 100])
-        if ch == station.channel_nomenclature_obj.hy:
+        if ch == station.channel_nomenclature.hy:
             nan_indices[ch].append([11, 100])
             nan_indices[ch].append([20000, 444])
     run_001.nan_indices = nan_indices
@@ -279,11 +278,11 @@ def make_station_01(channel_nomenclature: SupportedNomenclature = "default") -> 
     # assign some filters to the channels
     filters = {}
     for ch in run_001.channels:
-        if ch in station.channel_nomenclature_obj.ex_ey:
+        if ch in station.channel_nomenclature.ex_ey:
             filters[ch] = [
                 FILTERS["1x"].name,
             ]
-        elif ch in station.channel_nomenclature_obj.hx_hy_hz:
+        elif ch in station.channel_nomenclature.hx_hy_hz:
             filters[ch] = [
                 FILTERS["10x"].name,
                 FILTERS["0.1x"].name
@@ -293,7 +292,6 @@ def make_station_01(channel_nomenclature: SupportedNomenclature = "default") -> 
     station.runs = [
         run_001,
     ]
-    # station.station_metadata.run_list = [run_001, ]  # TODO: delete if not needed
 
     return station
 
@@ -341,7 +339,7 @@ def make_station_03(channel_nomenclature: SupportedNomenclature = "default") -> 
     )
     station.mth5_name = "test3.h5"
 
-    channels = station.channel_nomenclature_obj.channels
+    channels = station.channel_nomenclature.channels
 
     nan_indices = {}
     for ch in channels:
@@ -349,11 +347,11 @@ def make_station_03(channel_nomenclature: SupportedNomenclature = "default") -> 
 
     filters = {}
     for ch in channels:
-        if ch in station.channel_nomenclature_obj.ex_ey:
+        if ch in station.channel_nomenclature.ex_ey:
             filters[ch] = [
                 FILTERS["1x"].name,
             ]
-        elif ch in station.channel_nomenclature_obj.hx_hy_hz:
+        elif ch in station.channel_nomenclature.hx_hy_hz:
             filters[ch] = [FILTERS["10x"].name, FILTERS["0.1x"].name]
 
     run_001 = SyntheticRun(
@@ -438,7 +436,7 @@ def make_station_04(channel_nomenclature: SupportedNomenclature = "default") -> 
     run_001 = SyntheticRun(
         id="001",
         sample_rate=8.0,
-        channels=station.channel_nomenclature_obj.channels,
+        channels=station.channel_nomenclature.channels,
         raw_data_path=ASCII_DATA_PATH.joinpath("test1.asc"),
         start=None,
     )
@@ -446,11 +444,11 @@ def make_station_04(channel_nomenclature: SupportedNomenclature = "default") -> 
 
     filters = {}
     for ch in run_001.channels:
-        if ch in station.channel_nomenclature_obj.ex_ey:
+        if ch in station.channel_nomenclature.ex_ey:
             filters[ch] = [
                 FILTERS["1x"].name,
             ]
-        elif ch in station.channel_nomenclature_obj.hx_hy_hz:
+        elif ch in station.channel_nomenclature.hx_hy_hz:
             filters[ch] = [FILTERS["10x"].name, FILTERS["0.1x"].name]
     run_001.filters = filters
 

--- a/mth5/data/station_config.py
+++ b/mth5/data/station_config.py
@@ -203,7 +203,7 @@ class SyntheticStation(object):
         self,
         station_metadata: Station,
         mth5_name: Optional[Union[str, pathlib.Path]] = None,
-        channel_nomenclature: SupportedNomenclature = "default",
+        # channel_nomenclature: SupportedNomenclature = "default",  # no longer needed - 2025-02-12
     ) -> None:
         """
         Constructor.
@@ -220,34 +220,6 @@ class SyntheticStation(object):
         self.station_metadata = station_metadata
         self.runs = []
         self.mth5_name = mth5_name
-
-        # set channel names
-        self._channel_map = None
-        self.channel_nomenclature_keyword = channel_nomenclature
-        self.set_channel_map()
-
-    @property
-    def channel_map(self) -> dict:
-        """
-        Make self._channel_map if it isn't initialize already.
-
-        :rtype: dict
-        :return: The mappings between the standard channel names and the ones that will be used in the MTH5.
-
-        """
-        if self._channel_map is None:
-            self.set_channel_map()
-        return self._channel_map
-
-    def set_channel_map(self) -> None:
-        """
-        Populates a dictionary relating "actual" channel names to the standard names "hx", "hy", "hz", "ex", "ey"
-
-        """
-        channel_nomenclature = ChannelNomenclature(
-            keyword=self.channel_nomenclature_keyword
-        )
-        self._channel_map = channel_nomenclature.get_channel_map()
 
 
 def make_station_01(channel_nomenclature: SupportedNomenclature = "default") -> SyntheticStation:
@@ -269,16 +241,13 @@ def make_station_01(channel_nomenclature: SupportedNomenclature = "default") -> 
     station_metadata.channels_recorded = channel_nomenclature_obj.channels
 
     # initialize SyntheticStation
-    station = SyntheticStation(
-        station_metadata=station_metadata,
-        channel_nomenclature=channel_nomenclature
-    )
+    station = SyntheticStation(station_metadata=station_metadata)
     station.mth5_name = f"{station_metadata.id}.h5"
 
     run_001 = SyntheticRun(
         id="001",
         sample_rate=1.0,
-        channels = list(station.channel_map.values()),  # TODO test replace with channel_nomenclature_obj.channels
+        channels = channel_nomenclature_obj.channels,
         raw_data_path=ASCII_DATA_PATH.joinpath("test1.asc"),
         start=None,
     )
@@ -302,16 +271,17 @@ def make_station_01(channel_nomenclature: SupportedNomenclature = "default") -> 
                 FILTERS["1x"].name,
             ]
         elif ch in channel_nomenclature_obj.hx_hy_hz:
-            filters[ch] = [FILTERS["10x"].name, FILTERS["0.1x"].name]
+            filters[ch] = [
+                FILTERS["10x"].name,
+                FILTERS["0.1x"].name
+            ]
     run_001.filters = filters
 
     station.runs = [
         run_001,
     ]
-    station_metadata.run_list = [
-        run_001,
-    ]
-    station.station_metadata = station_metadata
+    # station.station_metadata.run_list = [run_001, ]  # TODO: delete if not needed
+
     return station
 
 
@@ -329,10 +299,12 @@ def make_station_02(channel_nomenclature: SupportedNomenclature = "default") -> 
     test2.station_metadata.id = "test2"
     test2.mth5_name = "test2.h5"
     test2.runs[0].raw_data_path = ASCII_DATA_PATH.joinpath("test2.asc")
+
     nan_indices = {}
     for channel in test2.runs[0].channels:
         nan_indices[channel] = []
     test2.runs[0].nan_indices = nan_indices
+
     return test2
 
 

--- a/mth5/data/station_config.py
+++ b/mth5/data/station_config.py
@@ -204,7 +204,7 @@ class SyntheticStation(object):
         self,
         station_metadata: Station,
         mth5_name: Optional[Union[str, pathlib.Path]] = None,
-        channel_nomenclature: SupportedNomenclature = "default",  # TODO: rename to channel_nomenclature_keyword
+        channel_nomenclature_keyword: SupportedNomenclature = "default",  # TODO: rename to channel_nomenclature_keyword
     ) -> None:
         """
         Constructor.
@@ -213,15 +213,15 @@ class SyntheticStation(object):
         :type id: Station
         :param mth5_name: The name of the h5 file to which the station data and metadata will be written.
         :type mth5_name: Optional[Union[str, pathlib.Path]]
-        :param channel_nomenclature: the keyword for the channel nomenclature
-        :type channel_nomenclature: str
+        :param channel_nomenclature_keyword: the keyword for the channel nomenclature
+        :type channel_nomenclature_keyword: str
 
 
         """
         self.station_metadata = station_metadata
         self.runs = []
         self.mth5_name = mth5_name
-        self.channel_nomenclature = channel_nomenclature
+        self.channel_nomenclature_keyword = channel_nomenclature_keyword
         self._channel_nomenclature_obj = None  # TODO: rename to channel_nomenclature
 
         self.station_metadata.channels_recorded = self.channel_nomenclature_obj.channels
@@ -229,7 +229,8 @@ class SyntheticStation(object):
     @property
     def channel_nomenclature_obj(self):  # TODO: rename to channel_nomenclature
         if self._channel_nomenclature_obj is None:
-            self._channel_nomenclature_obj = ChannelNomenclature(keyword=self.channel_nomenclature)
+            self._channel_nomenclature_obj = ChannelNomenclature(
+                keyword=self.channel_nomenclature_keyword)
         return self._channel_nomenclature_obj
 
 
@@ -251,7 +252,7 @@ def make_station_01(channel_nomenclature: SupportedNomenclature = "default") -> 
     # initialize SyntheticStation
     station = SyntheticStation(
         station_metadata=station_metadata,
-        channel_nomenclature=channel_nomenclature  # Needed to assign channel types in RunTS
+        channel_nomenclature_keyword=channel_nomenclature  # Needed to assign channel types in RunTS
     )
 
     station.mth5_name = f"{station_metadata.id}.h5"
@@ -336,7 +337,7 @@ def make_station_03(channel_nomenclature: SupportedNomenclature = "default") -> 
     station_metadata.id = "test3"
     station = SyntheticStation(
         station_metadata=station_metadata,
-        channel_nomenclature=channel_nomenclature
+        channel_nomenclature_keyword=channel_nomenclature
     )
     station.mth5_name = "test3.h5"
 
@@ -430,7 +431,7 @@ def make_station_04(channel_nomenclature: SupportedNomenclature = "default") -> 
 
     station = SyntheticStation(
         station_metadata=station_metadata,
-        channel_nomenclature=channel_nomenclature
+        channel_nomenclature_keyword=channel_nomenclature
     )
     station.mth5_name = "test_04_8Hz.h5"
 


### PR DESCRIPTION
These are aimed at making synthetic data more general and easier to work with.

- add some doc
- stop defaulting sample_rate to 1.0Hz (explicit every time)
- remove channel_nomenclature keyword from the SyntheticRun (it should only need channel names)
- add (temporarily) the SyntheticRun channel-map hanlders to SynteticStation (prbobaly will be removed)
 - get/set channel_map
- add channels_recorded to SyntheticStation metadata
- explicitly pass channel names list (not Nomenclature object) to SyntheticRun
- add error message to create_run_ts_from_synthetic_run to catch incorrect channel names